### PR TITLE
Update biopython version from 1.77 to 1.78

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biopython==1.77
+biopython==1.78
 Django==3.0.7
 django-filter==2.2.0
 django-datatables-view==1.19.1


### PR DESCRIPTION
The current webapp code seems to have been updated to no longer use Bio.Alphabet, which was deprecated in Biopython v1.78. Using current PlasmidWebApp code with Biopython v1.77 will result in "ValueError: Need a Nucleotide or Protein alphabet" when attempting to export plasmid sequences in Genbank format in the webapp.